### PR TITLE
Make installation and execution easier

### DIFF
--- a/bin/dts-generator
+++ b/bin/dts-generator
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('./dts-generator.js')

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 /// <reference path="./typings/tsd" />
+/// <reference path="./tsextra" />
 
 import fs = require('fs');
 import glob = require('glob');
@@ -9,11 +10,6 @@ import ts = require('typescript');
 interface DiagnosticTypeChecker extends ts.TypeChecker {
 	getEmitResolver(): ts.EmitResolver;
 }
-
-// declare module ts {
-// 	export function createEmitHostFromProgram(program: ts.Program): any;
-// 	export function emitFiles(resolver: ts.EmitResolver, host: any, targetSourceFile?: ts.SourceFile): ts.EmitResult;
-// }
 
 interface Options {
 	baseDir: string;

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 /// <reference path="./typings/tsd" />
+/// <reference path="./typings/typescript/typescript_internal" />
 /// <reference path="./tsextra" />
 
 import fs = require('fs');

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   "devDependencies": {
     "typescript": "https://github.com/Microsoft/typescript/archive/2052ac39588d04d21e8cbaf26a3cacdb1a4eb150.tar.gz",
     "tsd": "next"
+  },
+  "scripts": {
+    "install": "./setup.sh"
   }
 }

--- a/setup.sh
+++ b/setup.sh
@@ -4,9 +4,13 @@ if [ ! -d "node_modules" ]; then
 	npm install
 fi
 
-echo 'tsc built from 2052ac3 or later is necessary for success!'
-echo '(Run `npm install` inside node_module/typescript and then'
-echo ' run `jake LKG` to get it built in the right place)'
+# As long as we're using a pre-release typescript, we need to rebuild the
+# compiler. Once we switch to a real release, the next 4 lines can be removed.
+cd node_modules/typescript
+npm install
+./node_modules/.bin/jake LKG
+cd ../..
+
 tsd reinstall
 tsd rebundle
 rm -rf typings/typescript

--- a/tsextra.d.ts
+++ b/tsextra.d.ts
@@ -1,0 +1,9 @@
+/// <reference path="./typings/typescript/typescript.d.ts" />
+
+// These are declarations that exist on the typescript object but aren't currently included in the typescript.d.ts. This
+// file, and its reference in index.ts, may be removed if/when these functions are included in typescript.d.ts.
+
+declare module 'typescript' {
+	export function createEmitHostFromProgram(program: Program): any;
+	export function emitFiles(resolver: EmitResolver, host: any, targetSourceFile?: SourceFile): EmitResult;
+}

--- a/tsextra.d.ts
+++ b/tsextra.d.ts
@@ -1,9 +1,9 @@
-/// <reference path="./typings/typescript/typescript.d.ts" />
+/// <reference path="./typings/typescript/typescript" />
 
 // These are declarations that exist on the typescript object but aren't currently included in the typescript.d.ts. This
-// file, and its reference in index.ts, may be removed if/when these functions are included in typescript.d.ts.
+// file, and its reference in index.ts, may be removed if/when these functions are included in typescript.d.ts or
+// typescript_internal.d.ts.
 
 declare module 'typescript' {
-	export function createEmitHostFromProgram(program: Program): any;
 	export function emitFiles(resolver: EmitResolver, host: any, targetSourceFile?: SourceFile): EmitResult;
 }


### PR DESCRIPTION
- `npm install` does everything
- squelch the compile errors
- add a run script