### PR TITLE
fix(fileName): normalize fileName for PCs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -144,7 +144,7 @@ export function generate(options: Options, sendMessage: (message: string) => voi
 		program.getSourceFiles().some(function (sourceFile) {
 			// Source file is a default library, or other dependency from another project, that should not be included in
 			// our bundled output
-			if (sourceFile.fileName.indexOf(baseDir) !== 0) {
+			if (pathUtil.normalize(sourceFile.fileName).indexOf(baseDir) !== 0) {
 				return;
 			}
 


### PR DESCRIPTION
The normalized file name allows the code to work properly on PCs

See #15