### PR TITLE
Reject a build if emit has diagnostic messages

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -161,7 +161,7 @@ export function generate(options: Options, sendMessage: (message: string) => voi
 			}
 
 			var emitOutput = program.emit(sourceFile, writeFile);
-			if (emitOutput.emitSkipped) {
+			if (emitOutput.emitSkipped || emitOutput.diagnostics.length > 0) {
 				reject(getError(
 					emitOutput.diagnostics
 						.concat(program.getSemanticDiagnostics(sourceFile))


### PR DESCRIPTION
emit can fail to produce typings even if it emits a typings file (so that `emitSkipped` is false), so `dis-generator` should also consider the presence of diagnostic messages. For example, the following class will result in an empty typings file because the exported class uses a private interface:

```js
interface I {
}

export class C {
	constructor(a: I) {
	}
}
```