### PR TITLE
Closes #22. Fixing the path comparision so that exclude can work in Windows as well

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -111,7 +111,7 @@ export function generate(options: Options, sendMessage: (message: string) => voi
 	var filenames = getFilenames(baseDir, options.files);
 	var excludesMap: { [filename: string]: boolean; } = {};
 	options.excludes && options.excludes.forEach(function (filename) {
-		excludesMap[pathUtil.resolve(baseDir, filename)] = true;
+		excludesMap[filenameToMid(pathUtil.resolve(baseDir, filename))] = true;
 	});
 
 	mkdirp.sync(pathUtil.dirname(options.out));
@@ -148,7 +148,7 @@ export function generate(options: Options, sendMessage: (message: string) => voi
 				return;
 			}
 
-			if (excludesMap[sourceFile.fileName]) {
+			if (excludesMap[filenameToMid(pathUtil.normalize(sourceFile.fileName))]) {
 				return;
 			}
 

--- a/typings/typescript/typescript.d.ts
+++ b/typings/typescript/typescript.d.ts
@@ -1,1 +1,1 @@
-../../node_modules/typescript/bin/typescript.d.ts
+/// <reference path="../../node_modules/typescript/bin/typescript.d.ts" />


### PR DESCRIPTION
Fixing the path comparision so that exclude can work in Windows as well (1.4 branch)