### PR TITLE
Fix #27. Wrong generation from node_modules module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ import Foo = require('package-name/Foo');
 
 * `baseDir: string`: The base directory for the package being bundled. Any dependencies discovered outside this
   directory will be excluded from the bundle.
-* `excludes?: string[]`: A list of files, relative to `baseDir`, that should be excluded from the bundle. Use the
-  `--exclude` flag one or more times on the command-line.
+* `excludes?: string[]`: A list of glob patterns, relative to `baseDir`, that should be excluded from the bundle. Use
+  the `--exclude` flag one or more times on the command-line. Defaults to `[ "node_modules/**/*.d.ts" ]`.
 * `externs?: string[]`: A list of external module reference paths that should be inserted as reference comments. Use
   the `--extern` flag one or more times on the command-line.
 * `files: string[]`: A list of files from the baseDir to bundle.

--- a/index.ts
+++ b/index.ts
@@ -148,6 +148,12 @@ export function generate(options: Options, sendMessage: (message: string) => voi
 				return;
 			}
 
+			// the source file is inside a node_modules folder, so it should not be included into our
+			// bundled output, even if it is inside our project
+			if (/[\\/]node_modules[\\/]/.test(pathUtil.normalize(sourceFile.fileName))) {
+				return;
+			}
+
 			if (excludesMap[filenameToMid(pathUtil.normalize(sourceFile.fileName))]) {
 				return;
 			}

--- a/index.ts
+++ b/index.ts
@@ -110,8 +110,13 @@ export function generate(options: Options, sendMessage: (message: string) => voi
 
 	var filenames = getFilenames(baseDir, options.files);
 	var excludesMap: { [filename: string]: boolean; } = {};
+
+	options.excludes = options.excludes || [ "node_modules/**/*.d.ts" ];
+
 	options.excludes && options.excludes.forEach(function (filename) {
-		excludesMap[filenameToMid(pathUtil.resolve(baseDir, filename))] = true;
+		glob.sync(filename).forEach(function(globFileName) {
+			excludesMap[filenameToMid(pathUtil.resolve(baseDir, globFileName))] = true;
+		});
 	});
 
 	mkdirp.sync(pathUtil.dirname(options.out));
@@ -145,12 +150,6 @@ export function generate(options: Options, sendMessage: (message: string) => voi
 			// Source file is a default library, or other dependency from another project, that should not be included in
 			// our bundled output
 			if (pathUtil.normalize(sourceFile.fileName).indexOf(baseDir) !== 0) {
-				return;
-			}
-
-			// the source file is inside a node_modules folder, so it should not be included into our
-			// bundled output, even if it is inside our project
-			if (/[\\/]node_modules[\\/]/.test(pathUtil.normalize(sourceFile.fileName))) {
 				return;
 			}
 


### PR DESCRIPTION
Turns out the issue happens when you want to generate your `.d.ts` file in the root of your project. Since the typescript.d.ts is inside the node_modules it actually matches that it's a transitive dependency from inside your baseDir (that is ./).