### PR TITLE
Updated grunt task

### DIFF
--- a/tasks/dtsGenerator.js
+++ b/tasks/dtsGenerator.js
@@ -8,7 +8,11 @@ module.exports = function (grunt) {
 		var kwArgs = this.options();
 		kwArgs.sendMessage = grunt.verbose.writeln.bind(grunt.verbose);
 		kwArgs.files = this.filesSrc.map(function (filename) {
-			return path.relative(kwArgs.baseDir, filename);
+			if (kwArgs.hasOwnProperty('baseDir')) {
+				return path.relative(kwArgs.baseDir, filename);
+			}  else {
+				return path.relative(kwArgs.project, filename);
+			}
 		});
 
 		dtsGenerator(kwArgs).then(function () {


### PR DESCRIPTION
Reflected change from baseDir => project currently missing in grunt task

Currently, you have to specify both "baseDir" and "project" in the Grunt options.