### PR TITLE
Fixed a bug about excluded paths as reported in #112.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ import Foo = require('package-name/Foo');
 ## Options
 
 * `baseDir?: string`: The base directory for the package being bundled. Any dependencies discovered outside this
-  directory will be excluded from the bundle.  *Note* this is no longer the preferred way to configure `dts-generator`, please see `project`.
+  directory will be excluded from the bundle.  *Note* this is no longer the preferred way to configure `dts-generator`, 
+  it automatically gets its value from compiler option `rootDir` if specified in `tsconfig.json`, otherwise it gets value from `project`. Please see option `project`.
 * `exclude?: string[]`: A list of glob patterns, relative to `baseDir`, that should be excluded from the bundle. Use
   the `--exclude` flag one or more times on the command-line. Defaults to `[ "node_modules/**/*.d.ts" ]`.
 * `externs?: string[]`: A list of external module reference paths that should be inserted as reference comments. Use

--- a/index.ts
+++ b/index.ts
@@ -273,7 +273,7 @@ export default function generate(options: Options): Promise<void> {
 	options.exclude = options.exclude || [ 'node_modules/**/*.d.ts' ];
 
 	options.exclude && options.exclude.forEach(function (filename) {
-		glob.sync(filename).forEach(function(globFileName) {
+		glob.sync(filename, { cwd: baseDir }).forEach(function(globFileName) {
 			excludesMap[filenameToMid(pathUtil.resolve(baseDir, globFileName))] = true;
 		});
 	});


### PR DESCRIPTION
Fixed a bug about excluded paths as reported in #112 ; Added more description for option `baseDir` in README.md so that readers can understand the phase "relative to `baseDir`" in `exclude` description.