### PR TITLE
fix test of source filename against baseDir

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -338,7 +338,7 @@ export default function generate(options: Options): Promise<void> {
 		program.getSourceFiles().some(function (sourceFile) {
 			// Source file is a default library, or other dependency from another project, that should not be included in
 			// our bundled output
-			if (pathUtil.normalize(sourceFile.fileName).indexOf(baseDir) !== 0) {
+			if (pathUtil.normalize(sourceFile.fileName).indexOf(baseDir + pathUtil.sep) !== 0) {
 				return;
 			}
 


### PR DESCRIPTION
I found this bug in a repo containing 2 projects `foo` and `foobar` where `foo` depends on `foobar` and the dependency is setup with `npm link`.

In this configuration, the generated `.d.ts` for `foo` contains type definitions for both `foo` and `foobar` modules, when it should only contain definitions for the `foo` module.

This problem only shows up if the importing project name (`foo`) is a prefix of the imported project name (`foobar`), and if the projects are npm linked.

I fixed it by strengthening the test of filenames against `baseDir`.