### PR TITLE
Improve error message and documentation related to 'options.prefix'

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ import Foo = require('package-name/Foo');
 ## Options
 
 * `baseDir?: string`: The base directory for the package being bundled. Any dependencies discovered outside this
-  directory will be excluded from the bundle.  *Note* this is no longer the preferred way to configure `dts-generator`, 
+  directory will be excluded from the bundle.  *Note* this is no longer the preferred way to configure `dts-generator`,
   it automatically gets its value from compiler option `rootDir` if specified in `tsconfig.json`, otherwise it gets value from `project`. Please see option `project`.
 * `exclude?: string[]`: A list of glob patterns, relative to `baseDir`, that should be excluded from the bundle. Use
   the `--exclude` flag one or more times on the command-line. Defaults to `[ "node_modules/**/*.d.ts" ]`.
@@ -85,6 +85,7 @@ import Foo = require('package-name/Foo');
 * `moduleResolution?: ts.ModuleResolutionKind`: The type of module resolution to use when generating the bundle.
 * `name: string`: The name of the package. Used to determine the correct exported package name for modules.
 * `out: string`: The filename where the generated bundle will be created.
+* `prefix: string`: Used to prefix imports and module names in the output.
 * `project?: string`: The base directory for the project being bundled.  It is assumed that this directory contains a `tsconfig.json` which will be parsed to determine the files that should be bundled as well as other configuration information like `target`
 * `target?: ts.ScriptTarget`: The target environment for generated code. Defaults to `ts.ScriptTarget.Latest`.
 * `resolveModuleId: (params: ResolveModuleIdParams) => string`: An optional callback provided by the invoker to customize the declared module ids the output d.ts files. For details see [resolving module ids](docs/resolving-module-ids.md).

--- a/index.ts
+++ b/index.ts
@@ -195,7 +195,7 @@ export default function generate(options: Options): Promise<void> {
 			throw new Error(
 				`name and main must be used together.  Perhaps you want prefix instead of
 				name? In dts-generator version 2.1, name did double duty as the option to
-				use to prefix module names with, but in >=2.2 the name option was split
+				use to prefix module names with, but in >2.1 the name option was split
 				into two; prefix is what is now used to prefix imports and module names
 				in the output.`
 			);
@@ -352,6 +352,10 @@ export default function generate(options: Options): Promise<void> {
 			if (sourceFile.fileName.slice(-DTSLEN) === '.d.ts') {
 				writeDeclaration(sourceFile, false);
 				return;
+			}
+
+			if (!options.prefix) {
+				throw new Error("When using 'options.name' you must also specify 'options.prefix'");
 			}
 
 			// We can optionally output the main module if there's something to export.

--- a/index.ts
+++ b/index.ts
@@ -354,7 +354,7 @@ export default function generate(options: Options): Promise<void> {
 				return;
 			}
 
-			if (!options.prefix) {
+			if (options.main && !options.prefix) {
 				throw new Error("When using 'options.name' you must also specify 'options.prefix'");
 			}
 

--- a/tslint.json
+++ b/tslint.json
@@ -35,7 +35,7 @@
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
+		"quotemark": [ true, "single", "avoid-escape" ],
 		"radix": true,
 		"semicolon": true,
 		"trailing-comma": [ true, {


### PR DESCRIPTION
README.md: add documentation for `options.prefix`
index.ts: add error message if `options.prefix` is not specified with `options.main`

Fixes #121