### PR TITLE
Replace relative paths when exporting from d.ts with added tests

### DIFF
--- a/tests/support/foo-relative-path/sub/bar.d.ts
+++ b/tests/support/foo-relative-path/sub/bar.d.ts
@@ -1,0 +1,1 @@
+export * from './folder/bar/bar';

--- a/tests/support/foo-relative-path/sub/baz.d.ts
+++ b/tests/support/foo-relative-path/sub/baz.d.ts
@@ -1,0 +1,1 @@
+export * from './baz/baz';

--- a/tests/support/foo-relative-path/sub/baz/baz.d.ts
+++ b/tests/support/foo-relative-path/sub/baz/baz.d.ts
@@ -1,0 +1,1 @@
+export * from '../folder/bar/bar';

--- a/tests/support/foo-relative-path/sub/folder/bar/bar.d.ts
+++ b/tests/support/foo-relative-path/sub/folder/bar/bar.d.ts
@@ -1,0 +1,4 @@
+export declare interface Bar {
+	bar: string;
+	foo: number;
+}

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -206,7 +206,7 @@ registerSuite('index', {
 			assert.include(contents, `declare module 'foo/FooImplExportDeclaration'`);
 		});
 	},
-	'add reference types package dependency  ': function () {
+	'add reference types package dependency': function () {
 		return generate({
 			baseDir: 'tests/support/foo',
 			files: [ 'index.ts' ],
@@ -217,7 +217,7 @@ registerSuite('index', {
 			assert.include(contents, `/// <reference types="es6-promise" />`);
 		});
 	},
-	'add external path dependency  ': function () {
+	'add external path dependency': function () {
 		return generate({
 			baseDir: 'tests/support/foo',
 			files: [ 'index.ts' ],

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -227,5 +227,19 @@ registerSuite('index', {
 			const contents = fs.readFileSync('tmp/foo.d.ts', { encoding: 'utf8' });
 			assert.include(contents, `/// <reference path="../some/path/es6-promise.d.ts" />`);
 		});
+	},
+	'project with relative imports in .d.ts files': function () {
+		return generate({
+			baseDir: 'tests/support/foo-relative-path',
+			files: [ 'sub/bar.d.ts', 'sub/baz.d.ts' ],
+			out: 'tmp/foo.d.ts'
+		}).then(function () {
+			const contents = fs.readFileSync('tmp/foo.d.ts', { encoding: 'utf8' });
+			assert.include(contents, `export * from 'sub/folder/bar/bar'`);
+			assert.include(contents, `export * from 'sub/baz/baz'`);
+
+			// all relative paths should be replaced with absolute ones so there should be no exports like this
+			assert.notInclude(contents, `export * from '.`);
+		});
 	}
 });


### PR DESCRIPTION
Related to #65
When relative paths are used as in angular .d.ts files those relative paths to be changed to absolute when merging the .d.ts files.
Added a test for the change as well.